### PR TITLE
combined `stop` and `speed` control into one working version

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,27 @@
+// This is a modified version of say.js by Marak Squires http://github.com/marak/say.js/
+
+/*
+Copyright (c) 2010 Marak Squires http://github.com/marak/say.js/
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
 'use strict';
-
 var spawn = require('child_process').spawn,
-  child;
-
+var speechProcess;
 var say = exports;
 
 if (process.platform === 'darwin') {
@@ -37,10 +56,10 @@ exports.speak = function(voice, text, callback, speed) {
   }
 
 
-  var childD = spawn(say.speaker, commands);
+ speechProcess = spawn(say.speaker, commands);
+  speechProcess.stdin.setEncoding('ascii');
+  speechProcess.stderr.setEncoding('ascii');
 
-  childD.stdin.setEncoding('ascii');
-  childD.stderr.setEncoding('ascii');
 
   if (process.platform === 'linux') {
     childD.stdin.end(pipedData);
@@ -51,31 +70,19 @@ exports.speak = function(voice, text, callback, speed) {
   childD.stdout.on('data', function(data){ console.log(data); });
 
 
-  childD.addListener('exit', function (code, signal) {
-    if (code === null || signal !== null) {
+ speechProcess.addListener('exit', function (code, signal) {
+    if(code == null || signal != null) {
       console.log('couldnt talk, had an error ' + '[code: '+ code + '] ' + '[signal: ' + signal + ']');
     }
 
-    ////STOP TEST
-     child = null;
-    //
-    // handle callback if given
-    if (callback) {
-      // we could do better than a try / catch here
-      try {
-        callback();
-      } catch(err) {
-        // noop
-      }
-    }
+    if ( callback ){ callback() }
   });
-};
+}
 
-//STOP TEST
-exports.stop = function () {
-  if (!child) {
-    return;
-  }
-  child.stdin.pause();
-  child.kill();
+
+// this stop function from a pull request on say.js (https://github.com/lakenen/say.js/blob/stop/lib/say.js)
+exports.stop = function(){
+  if (!speechProcess){ return; }
+  speechProcess.stdin.pause();
+  speechProcess.kill();
 }

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-// This is a modified version of say.js by Marak Squires http://github.com/marak/say.js/
+/* This is a modified version of say.js by Marak Squires http://github.com/marak/say.js/ */
 
 /*
 Copyright (c) 2010 Marak Squires http://github.com/marak/say.js/

--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ else if (process.platform === 'linux') {
 }
 
 // say stuff, speak
-exports.speak = function(voice, text, callback) {
+exports.speak = function(voice, text, callback, speed) {
   var commands,
     pipedData;
 
@@ -27,6 +27,9 @@ exports.speak = function(voice, text, callback) {
       commands = [ text ];
     } else {
       commands = [ '-v', voice, text];
+    }
+    if (speed) {
+      commands.push('-r', speed);
     }
   } else if (process.platform === 'linux') {
     commands = ['--pipe'];
@@ -53,27 +56,26 @@ exports.speak = function(voice, text, callback) {
       console.log('couldnt talk, had an error ' + '[code: '+ code + '] ' + '[signal: ' + signal + ']');
     }
 
-    // we could do better than a try / catch here
-    try {
-      callback();
-    } catch(err) {
-      // noop
+    ////STOP TEST
+     child = null;
+    //
+    // handle callback if given
+    if (callback) {
+      // we could do better than a try / catch here
+      try {
+        callback();
+      } catch(err) {
+        // noop
+      }
     }
   });
 };
 
-/*
-    This code doesnt work....but it could!
-    // monkey punch sys.puts to speak, lol
-    say.puts();
-
-    sys.puts('whats, up dog?'); // did you hear that?
-    exports.puts = function(){
-
-      var s2 = require('util');
-      // don't try this at home
-      sys.puts = function(text){
-        s2.puts(text);
-      };
-    }
-*/
+//STOP TEST
+exports.stop = function () {
+  if (!child) {
+    return;
+  }
+  child.stdin.pause();
+  child.kill();
+}

--- a/index.js
+++ b/index.js
@@ -19,8 +19,8 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
-'use strict';
-var spawn = require('child_process').spawn,
+//'use strict';
+var spawn = require('child_process').spawn;
 var speechProcess;
 var say = exports;
 

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
-//'use strict';
+// 'use strict';
 var spawn = require('child_process').spawn;
 var speechProcess;
 var say = exports;
@@ -62,12 +62,12 @@ exports.speak = function(voice, text, callback, speed) {
 
 
   if (process.platform === 'linux') {
-    childD.stdin.end(pipedData);
+    speechProcess.stdin.end(pipedData);
   }
 
 
-  childD.stderr.on('data', function(data){ console.log(data); });
-  childD.stdout.on('data', function(data){ console.log(data); });
+  speechProcess.stderr.on('data', function(data){ console.log(data); });
+  speechProcess.stdout.on('data', function(data){ console.log(data); });
 
 
  speechProcess.addListener('exit', function (code, signal) {
@@ -75,7 +75,16 @@ exports.speak = function(voice, text, callback, speed) {
       console.log('couldnt talk, had an error ' + '[code: '+ code + '] ' + '[signal: ' + signal + ']');
     }
 
-    if ( callback ){ callback() }
+    if ( callback ){
+        try {
+        callback();
+      } catch(err) {
+        // noop
+      }
+
+    }
+
+
   });
 }
 


### PR DESCRIPTION
combined `stop` and `speed` control into one working version, combining code from two different full requests.


**speed** function from a pull request
[https://github.com/Marak/say.js/pull/21](https://github.com/mwitte/say.js/blob/master/index.js)

```javascript
// say stuff, speak
exports.speak = function(voice, text, callback, speed) {
  var commands,
    pipedData;

  if (arguments.length < 2) {
    console.log('invalid amount of arguments sent to speak()');
    return;
  }

  if (process.platform === 'darwin') {
    if (!voice) {
      commands = [ text ];
    } else {
      commands = [ '-v', voice, text];
    }
    if (speed) {
      commands.push('-r', speed);
    }
  } else if (process.platform === 'linux') {
    commands = ['--pipe'];
    pipedData = '(' + voice + ') (SayText \"' + text + '\")';
  }
  ```


**stop** function from a pull request on [https://github.com/Marak/say.js/pull/10](https://github.com/lakenen/say.js/blob/stop/lib/say.js) 

```javascript
exports.stop = function () {
  if (!child) {
    return;
  }
  child.stdin.pause();
  child.kill();
}
```

as well as 

[https://github.com/thomascullen/voicebox/blob/6bffff743f86d9662c0a5f9e5d609b2e45216e13/say.js]