### PR TITLE
Normalizing speed for OSX and Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ say.speak('Hello!');
 say.stop();
 
 // More complex example (with an OS X voice) and slow speed
-say.speak('whats up, dog?', 'Alex', 20);
+say.speak('whats up, dog?', 'Alex', 0.5);
 
 // Fire a callback once the text has completed being spoken
-say.speak('whats up, dog?', 'Good News', null, function(err) {
+say.speak('whats up, dog?', 'Good News', 1.0, function(err) {
   if (err) {
     return console.error(err);
   }
@@ -32,7 +32,7 @@ say.speak('whats up, dog?', 'Good News', null, function(err) {
 });
 
 // Export spoken audio to a WAV file
-say.export("I'm sorry, Dave.", 'Cellos', 150, 'hal.wav', function(err) {
+say.export("I'm sorry, Dave.", 'Cellos', 0.75, 'hal.wav', function(err) {
   if (err) {
     return console.error(err);
   }
@@ -43,8 +43,6 @@ say.export("I'm sorry, Dave.", 'Cellos', 150, 'hal.wav', function(err) {
 
 
 ## OS X Notes
-
-Speed is based on the average number of words spoken per minute. The OS X `say` command seems to default to 175.
 
 ### Feminine Voices
 
@@ -72,8 +70,6 @@ The `export` method is not available.
 Linux support involves the use of [Festival](http://www.cstr.ed.ac.uk/projects/festival/), which uses decidedly less friendly names for its voices.  Voices for
 Festival sometimes need to be installed separately - you can check which voices are available by starting up Festival in interactive mode, typing `(voice_`,
 and pressing `TAB`.  Then take the name of the voice you'd like to try, minus the parentheses, and pass it in to say.js.
-
-Speed is a percent based upon the normal rate, so 50 is 50%, 120 is 120%, etc. This differs from OS X.
 
 The `export` method is not yet available.
 

--- a/examples/all-demo.js
+++ b/examples/all-demo.js
@@ -6,7 +6,7 @@ var say = require('../');
 
 var text = 'This is Ground Control to Major Tom This is Ground Control to Major Tom This is Ground Control to Major Tom';
 var voice = undefined;
-var speed = 120;
+var speed = 2.0;
 
 // output some text to the console as the callback
 say.speak(text, voice, speed, function(error) {

--- a/examples/osx-demo.js
+++ b/examples/osx-demo.js
@@ -8,10 +8,10 @@ var say = require('../');
 say.speak('whats up, dog?', 'Alex');
 
 // no callback, fire and forget
-say.speak('whats up, dog?', 'Cellos', 20);
+say.speak('whats up, dog?', 'Cellos', 0.5);
 
 // output some text to the console as the callback
-say.speak('whats up, dog?', 'Good News', undefined, function (error) {
+say.speak('whats up, dog?', 'Good News', 1.0, function (error) {
   if (error) {
     console.log(error);
   }

--- a/examples/osx-export.js
+++ b/examples/osx-export.js
@@ -5,7 +5,7 @@
 var say = require('../');
 
 // no callback, fire and forget
-say.export('whats up, dog?', 'Alex', 30, './exported.wav', function (error){
+say.export('whats up, dog?', 'Alex', 0.5, './exported.wav', function (error){
   if (error) {
     return console.log(error);
   }

--- a/index.js
+++ b/index.js
@@ -7,8 +7,10 @@ var childD;
 // use the correct library per platform
 if (process.platform === 'darwin') {
   say.speaker = 'say';
+  say.base_speed = 175;
 } else if (process.platform === 'linux') {
   say.speaker = 'festival';
+  say.base_speed = 100;
 } else if (process.platform === 'win32') {
   say.speaker = 'cmd';
 }
@@ -18,7 +20,7 @@ if (process.platform === 'darwin') {
  *
  * @param {string} text Text to be spoken
  * @param {string|null} voice Name of voice to be spoken with
- * @param {number|null} speed Speed of text (On OSX this is Word per Minute, Linux is percent of normal e.g. 100)
+ * @param {number|null} speed Speed of text (e.g. 1.0 for normal, 0.5 half, 2.0 double)
  * @param {Function|null} callback A callback of type function(err) to return.
  */
 say.speak = function(text, voice, speed, callback) {
@@ -42,13 +44,13 @@ say.speak = function(text, voice, speed, callback) {
     }
 
     if (speed) {
-      commands.push('-r', speed);
+      commands.push('-r', convertSpeed(speed));
     }
   } else if (process.platform === 'linux') {
     commands = ['--pipe'];
 
     if (speed) {
-      pipedData = '(Parameter.set \'Audio_Command "aplay -q -c 1 -t raw -f s16 -r $(($SR*' + speed + '/100)) $FILE") ';
+      pipedData = '(Parameter.set \'Audio_Command "aplay -q -c 1 -t raw -f s16 -r $(($SR*' + convertSpeed(speed) + '/100)) $FILE") ';
     }
 
     if (voice) {
@@ -118,7 +120,7 @@ say.export = function(text, voice, speed, filename, callback) {
     }
 
     if (speed) {
-      commands.push('-r', speed);
+      commands.push('-r', convertSpeed(speed));
     }
 
     if (filename){
@@ -186,3 +188,7 @@ exports.stop = function(callback) {
 
   callback(null);
 };
+
+function convertSpeed(speed) {
+  return Math.ceil(say.base_speed * speed);
+}


### PR DESCRIPTION
This change normalizes OSX say and Linux festival commands so that the same speed parameter will result in the same speed.

The speed parameter is now a float. 1.0 is normal human talking speed, 0.5 is half speed, 2.0 is double speed, etc.