### PR TITLE
Windows platform: Modified stop() to also kill vbscript process

### DIFF
--- a/index.js
+++ b/index.js
@@ -181,6 +181,13 @@ exports.stop = function(callback) {
     // aplay process. Kill that and the audio actually stops.
     process.kill(childD.pid + 2);
   } else {
+    if (process.platform === 'win32') {
+      // Temporary solution to kill wscript process - currently only kills the cmd process
+      // so audio continues playing even after calling stop(). Spawns new terminal to
+      // perform taskkill as childD is still locked in WaitUntilDone
+      var killVBS = spawn('cmd', []);
+      killVBS.stdin.write("taskkill /f /im wscript.exe\n");
+    }
     childD.stdin.pause();
     childD.kill('SIGINT');
   }


### PR DESCRIPTION
I noticed that the stop() function wasn't working for the Windows platform. It seems that the VBScript process is not killed at the same time as the cmd process, so I added a temporary workaround by taskkilling the wscript.exe process. I'm still learning JavaScript, so this may not be the best solution!