### PR TITLE
Fix Speaking Multiline Text On Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ if (process.platform === 'darwin') {
   say.speaker = 'festival';
   say.base_speed = 100;
 } else if (process.platform === 'win32') {
-  say.speaker = 'cmd';
+  say.speaker = 'powershell';
 }
 
 /**
@@ -60,7 +60,8 @@ say.speak = function(text, voice, speed, callback) {
 
     pipedData += '(SayText \"' + text + '\")';
   } else if (process.platform === 'win32') {
-    commands = [ '/s /c "' + path.join(__dirname, 'say.vbs') + ' ' + JSON.stringify(text) + '"' ];
+    pipedData = text;
+    commands = [ 'Add-Type -AssemblyName System.speech; $speak = New-Object System.Speech.Synthesis.SpeechSynthesizer; $speak.Speak([Console]::In.ReadToEnd())' ];
   } else {
     // if we don't support the platform, callback with an error (next tick) - don't continue
     return process.nextTick(function() {
@@ -68,7 +69,7 @@ say.speak = function(text, voice, speed, callback) {
     });
   }
 
-  var options = (process.platform === 'win32') ? { windowsVerbatimArguments: true } : undefined;
+  var options = (process.platform === 'win32') ? { shell: true } : undefined;
   childD = child_process.spawn(say.speaker, commands, options);
 
   childD.stdin.setEncoding('ascii');

--- a/say.vbs
+++ b/say.vbs
@@ -1,4 +1,0 @@
-'say.vbs
-set s = CreateObject("SAPI.SpVoice")
-s.Speak Wscript.Arguments(0), 3
-s.WaitUntilDone(-1)


### PR DESCRIPTION
Issue #44

**Bug**
Due to `JSON.stringify` being used to escape command line arguments to the vbscript on windows, newlines (or other special characters) end up being spoken too literally on windows.

**Fix**
Switch to use stdin to pipe text to the script. Also switches to use powershell instead of vbscript since powershell plays more nicely with stdin.

**Testing**
Ran basic example script on windows to confirm things still work.

Closes #44
