### PR TITLE
Fix umlauts being ignored

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ say.speak = function(text, voice, speed, callback) {
     pipedData += '(SayText \"' + text + '\")';
   } else if (process.platform === 'win32') {
     pipedData = text;
-    commands = [ 'Add-Type -AssemblyName System.speech; $speak = New-Object System.Speech.Synthesis.SpeechSynthesizer; $speak.Speak([Console]::In.ReadToEnd())' ];
+    commands = [ 'Add-Type -AssemblyName System.speech; $speak = New-Object System.Speech.Synthesis.SpeechSynthesizer; [Console]::InputEncoding = [System.Text.Encoding]::UTF8; $speak.Speak([Console]::In.ReadToEnd())' ];
   } else {
     // if we don't support the platform, callback with an error (next tick) - don't continue
     return process.nextTick(function() {


### PR DESCRIPTION
When trying to speak German texts the umlauts used to be ignored on Windows due to the default encoding.
Setting it explicitly to UTF-8 fixes this error.
The fix was discovered by @hilderonny on issue #49. I can confirm it is working as intended.

Resolves: #49