### PR TITLE
Updated windows to support the `voice` parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Platform | Speak | Export | Stop | Speed | Voice
 ---------|-------|--------|------|-------|------
 macOS    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: 
 Linux    | :white_check_mark: | :no_entry_sign:    | :white_check_mark: | :white_check_mark: | :white_check_mark: 
-Windows  | :white_check_mark: | :no_entry_sign:    | :white_check_mark: | :white_check_mark:    | :no_entry_sign:
+Windows  | :white_check_mark: | :no_entry_sign:    | :white_check_mark: | :no_entry_sign:    | :white_check_mark:
 
 
 ## macOS Notes
@@ -96,7 +96,7 @@ As an example, the default voice is `Alex` and the voice used by Siri is `Samant
 
 ## Windows Notes
 
-Voice parameter is not yet available. Uses whatever default system voice is set, ignoring voice parameter.
+Speed parameter is not yet available.
 
 The `.export()` method is not available.
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Platform | Speak | Export | Stop | Speed | Voice
 ---------|-------|--------|------|-------|------
 macOS    | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: 
 Linux    | :white_check_mark: | :no_entry_sign:    | :white_check_mark: | :white_check_mark: | :white_check_mark: 
-Windows  | :white_check_mark: | :no_entry_sign:    | :white_check_mark: | :no_entry_sign:    | :no_entry_sign:
+Windows  | :white_check_mark: | :no_entry_sign:    | :white_check_mark: | :white_check_mark:    | :no_entry_sign:
 
 
 ## macOS Notes
@@ -97,8 +97,6 @@ As an example, the default voice is `Alex` and the voice used by Siri is `Samant
 ## Windows Notes
 
 Voice parameter is not yet available. Uses whatever default system voice is set, ignoring voice parameter.
-
-Speed parameter is not yet available.
 
 The `.export()` method is not available.
 

--- a/examples/win32-allvoices.js
+++ b/examples/win32-allvoices.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+// Usage:
+//   ./allvoices.js
+//
+// Iterates over all supported voices and
+// repeats the input phrase
+
+const say = require('../')
+
+let voices = [
+    { voice: 'Microsoft David Desktop', text: 'No people recognize me by my voice.' },
+    { voice: 'Microsoft Zira Desktop', text: 'No people recognize me by my voice.' }
+]
+
+sayIt(0)
+
+function sayIt (voice) {
+  let v = voices[voice]
+  console.log(v.voice)
+
+  say.speak(v.text, v.voice, 1, (err) => {
+    voice++
+
+    if (err) {
+      console.error(err)
+    }
+
+    if (voice >= voices.length) {
+      process.exit(0)
+    }
+
+    sayIt(voice)
+  })
+}

--- a/platform/win32.js
+++ b/platform/win32.js
@@ -16,10 +16,21 @@ class SayPlatformWin32 extends SayPlatformBase {
     let pipedData = ''
     let options = {}
 
-    speed = this.convertSpeed(speed || 1)
+    let psCommand = `Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;`
+
+    if (speed) {
+      let adjustedSpeed = this.convertSpeed(speed || 1)
+      psCommand += `$speak.Rate = ${adjustedSpeed};`
+    }
+
+    if (voice) {
+      psCommand += `$speak.SelectVoice('${voice}');`
+    }
+
+    psCommand += `$speak.Speak([Console]::In.ReadToEnd())`
 
     pipedData += text
-    args.push(`Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;$speak.Rate = ${speed};$speak.Speak([Console]::In.ReadToEnd())`)
+    args.push(psCommand)
     options.shell = true
 
     return {command: COMMAND, args, pipedData, options}

--- a/platform/win32.js
+++ b/platform/win32.js
@@ -18,11 +18,6 @@ class SayPlatformWin32 extends SayPlatformBase {
 
     let psCommand = `Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;`
 
-    if (speed) {
-      let adjustedSpeed = this.convertSpeed(speed || 1)
-      psCommand += `$speak.Rate = ${adjustedSpeed};`
-    }
-
     if (voice) {
       psCommand += `$speak.SelectVoice('${voice}');`
     }
@@ -43,11 +38,6 @@ class SayPlatformWin32 extends SayPlatformBase {
   runStopCommand () {
     this.child.stdin.pause()
     childProcess.exec(`taskkill /pid ${this.child.pid} /T /F`)
-  }
-
-  convertSpeed (speed) {
-    // Overriden to map playback speed (as a ratio) to Window's values (-10 to 10, zero meaning x1.0)
-    return Math.max(-10, Math.min(Math.round((9.0686 * Math.log(speed)) - 0.1806), 10))
   }
 }
 

--- a/platform/win32.js
+++ b/platform/win32.js
@@ -16,8 +16,10 @@ class SayPlatformWin32 extends SayPlatformBase {
     let pipedData = ''
     let options = {}
 
+    speed = this.convertSpeed(speed || 1)
+
     pipedData += text
-    args.push('Add-Type -AssemblyName System.speech; $speak = New-Object System.Speech.Synthesis.SpeechSynthesizer; [Console]::InputEncoding = [System.Text.Encoding]::UTF8; $speak.Speak([Console]::In.ReadToEnd())')
+    args.push(`Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;$speak.Rate = ${speed};$speak.Speak([Console]::In.ReadToEnd())`)
     options.shell = true
 
     return {command: COMMAND, args, pipedData, options}
@@ -30,6 +32,11 @@ class SayPlatformWin32 extends SayPlatformBase {
   runStopCommand () {
     this.child.stdin.pause()
     childProcess.exec(`taskkill /pid ${this.child.pid} /T /F`)
+  }
+
+  convertSpeed (speed) {
+    // Overriden to map playback speed (as a ratio) to Window's values (-10 to 10, zero meaning x1.0)
+    return Math.max(-10, Math.min(Math.round((9.0686 * Math.log(speed)) - 0.1806), 10))
   }
 }
 


### PR DESCRIPTION
This adds support for specifying a voice when using Windows, working with #67 to round out the Windows features in #46.

I do have some questions as well, mostly about how missing or unknown voices should be handled. I can only speak to Windows right now, but getting a list of available voices (#16) is very simple. I know the other platforms have their own challenges, but should a "get list of voices" feature be implemented? Even if just used internally to first check if the voice specified exists. If the specified voice does not exist then ignore the parameter. The ability to write truly cross platform statements that gracefully revert to using the system defaults when needed is pretty nice.