### PR TITLE
windows support the buffer

### DIFF
--- a/platform/win32.js
+++ b/platform/win32.js
@@ -29,7 +29,7 @@ class SayPlatformWin32 extends SayPlatformBase {
 
     psCommand += `$speak.Speak([Console]::In.ReadToEnd())`
 
-    pipedData += text
+    pipedData = text
     args.push(psCommand)
     options.shell = true
 
@@ -59,7 +59,7 @@ class SayPlatformWin32 extends SayPlatformBase {
 
     psCommand += `$speak.Speak([Console]::In.ReadToEnd());$speak.Dispose()`
 
-    pipedData += text
+    pipedData = text
     args.push(psCommand)
     options.shell = true
 


### PR DESCRIPTION
eg: say.speak(require('iconv-lite').encode('测试一下', 'gbk'), null, 1);