### PR TITLE
Change powershell encoding to utf-8

### DIFF
--- a/platform/win32.js
+++ b/platform/win32.js
@@ -16,7 +16,8 @@ class SayPlatformWin32 extends SayPlatformBase {
     let pipedData = ''
     let options = {}
 
-    let psCommand = `Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;`
+    let psCommand = `chcp 65001;` // Change powershell encoding to utf-8
+    psCommand += `Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;`
 
     if (voice) {
       psCommand += `$speak.SelectVoice('${voice}');`
@@ -41,7 +42,8 @@ class SayPlatformWin32 extends SayPlatformBase {
     let pipedData = ''
     let options = {}
 
-    let psCommand = `Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;`
+    let psCommand = `chcp 65001;` // Change powershell encoding to utf-8
+    psCommand += `Add-Type -AssemblyName System.speech;$speak = New-Object System.Speech.Synthesis.SpeechSynthesizer;`
 
     if (voice) {
       psCommand += `$speak.SelectVoice('${voice}');`


### PR DESCRIPTION
In Japan, the default encoding of Powershell is Shift-JIS, but node passes characters in utf-8, so the correct characters were not read out.
I added `chcp 65001;` to change the character encoding of powershell from default to utf-8.
Now it is able to read out the characters correctly.